### PR TITLE
Fixed bug with i_total & test of all functions

### DIFF
--- a/src/InterfaceTest.cpp
+++ b/src/InterfaceTest.cpp
@@ -17,10 +17,15 @@ int main()
 	TRACSsim->set_vBias(400);
 	TRACSsim->calculate_fields();
 	TRACSsim->set_vBias(400);
+	TRACSsim->set_trappingTime(std::numeric_limits<double>::max()-100);
+	TRACSsim->set_neffType("Linear");
+	TRACSsim->set_carrierFile("etct.carriers");
+	TRACSsim->set_NeffParam({-25.,0.02,0.22,33.,0.,120.,220.,300});
 	TRACSsim->calculate_fields();
 	TRACSsim->simulate_ramo_current();
 	TRACSsim->GetItRamo();
-
+	TRACSsim->GetItRc();
+	TRACSsim->GetItConv();
 
 	
 	//std::cout<<"i_ramo:"<<TracsSim.GetItRamo()<<std::endl;

--- a/src/TRACSInterface.cpp
+++ b/src/TRACSInterface.cpp
@@ -25,12 +25,10 @@ TRACSInterface::TRACSInterface(std::string filename)
 
 	n_tSteps = (int) std::floor(max_time / dt);
 
-	std::valarray<double> i_elec ((size_t) n_tSteps);	
-	std::valarray<double> i_hole ((size_t) n_tSteps);
-	std::valarray<double> i_total((size_t) n_tSteps);
-	i_hole = 0;
-	i_elec = 0;
-	i_total = 0;
+	i_elec.resize((size_t) n_tSteps,0.);	
+	i_hole.resize ((size_t) n_tSteps,0.);
+	i_total.resize((size_t) n_tSteps,0.);
+	
 
 	parameters["allow_extrapolation"] = true;
 


### PR DESCRIPTION
Fixed resizing call (previous version was creating local variables, leading to segfault); successful test of TRACSInterface functions.
